### PR TITLE
Apt get switch

### DIFF
--- a/opsmop/providers/package/apt.py
+++ b/opsmop/providers/package/apt.py
@@ -24,7 +24,7 @@ class Apt(Package):
     
     def _get_version(self):
         version_check = VERSION_CHECK % self.name
-        output = self.test(version_check)
+        output = self.test(version_check).split(':')[1].strip()
         if output is None:
             return None
         return output      

--- a/opsmop/providers/package/apt.py
+++ b/opsmop/providers/package/apt.py
@@ -39,11 +39,17 @@ class Apt(Package):
         which = None
         if self.should('install'):
             self.do('install')
-            which = INSTALL.format(name=self.name)
+            if self.version:
+                which = INSTALL.format(name="{}={}".format(self.name, self.version))
+            else:
+                which = INSTALL.format(name=self.name)
         elif self.should('upgrade'):
             self.do('upgrade')
             # In apt-get, install also performs the task of upgrading a single package, so it is re-used
-            which = INSTALL.format(name=self.name)
+            if self.version:
+                which = INSTALL.format(name="{}={}".format(self.name, self.version))
+            else:
+                which = INSTALL.format(name=self.name)
         elif self.should('remove'):
             self.do('remove')
             which = UNINSTALL.format(name=self.name)

--- a/opsmop/providers/package/apt.py
+++ b/opsmop/providers/package/apt.py
@@ -16,9 +16,8 @@ from opsmop.providers.package.package import Package
 
 TIMEOUT = 60
 VERSION_CHECK = "dpkg -s %s | grep '^Version'"
-INSTALL = "apt install -y {name}"
-UPGRADE = "apt update -y {name}"
-UNINSTALL = "apt remove -y {name}"
+INSTALL = "apt-get -q=2 install -y {name}"
+UNINSTALL = "apt-get -q=2 remove -y {name}"
 
 class Apt(Package):
 
@@ -43,7 +42,8 @@ class Apt(Package):
             which = INSTALL.format(name=self.name)
         elif self.should('upgrade'):
             self.do('upgrade')
-            which = UPGRADE.format(name=self.name)
+            # In apt-get, install also performs the task of upgrading a single package, so it is re-used
+            which = INSTALL.format(name=self.name)
         elif self.should('remove'):
             self.do('remove')
             which = UNINSTALL.format(name=self.name)

--- a/opsmop/providers/package/apt.py
+++ b/opsmop/providers/package/apt.py
@@ -17,6 +17,7 @@ from opsmop.providers.package.package import Package
 TIMEOUT = 60
 VERSION_CHECK = "dpkg -s %s | grep '^Version'"
 INSTALL = "apt-get -q=2 install -y {name}"
+INSTALL_VERSION = "apt-get -q=2 install -y {name}={version}"
 UNINSTALL = "apt-get -q=2 remove -y {name}"
 
 class Apt(Package):
@@ -35,21 +36,23 @@ class Apt(Package):
     def plan(self):
         super().plan()
 
+    def _get_install_command(self):
+        """This decides whether we are going to install a specific version, or latest based on the presence of
+         self.version"""
+        if self.version:
+            return INSTALL_VERSION.format(name=self.name, version=self.version)
+        else:
+            return INSTALL.format(name=self.name)
+
     def apply(self):
         which = None
         if self.should('install'):
             self.do('install')
-            if self.version:
-                which = INSTALL.format(name="{}={}".format(self.name, self.version))
-            else:
-                which = INSTALL.format(name=self.name)
+            which = self._get_install_command()
         elif self.should('upgrade'):
             self.do('upgrade')
             # In apt-get, install also performs the task of upgrading a single package, so it is re-used
-            if self.version:
-                which = INSTALL.format(name="{}={}".format(self.name, self.version))
-            else:
-                which = INSTALL.format(name=self.name)
+            which = self._get_install_command()
         elif self.should('remove'):
             self.do('remove')
             which = UNINSTALL.format(name=self.name)

--- a/opsmop/providers/package/apt.py
+++ b/opsmop/providers/package/apt.py
@@ -16,6 +16,7 @@ from opsmop.providers.package.package import Package
 
 TIMEOUT = 60
 VERSION_CHECK = "dpkg -s %s | grep '^Version'"
+UPDATE_CACHE = "apt-get update -q=2"
 INSTALL = "apt-get -q=2 install -y {name}"
 INSTALL_VERSION = "apt-get -q=2 install -y {name}={version}"
 UNINSTALL = "apt-get -q=2 remove -y {name}"
@@ -46,6 +47,9 @@ class Apt(Package):
 
     def apply(self):
         which = None
+        if self.should('update_cache'):
+            self.do('update_cache')
+            self.run(UPDATE_CACHE)
         if self.should('install'):
             self.do('install')
             which = self._get_install_command()

--- a/opsmop/providers/package/apt.py
+++ b/opsmop/providers/package/apt.py
@@ -24,10 +24,10 @@ class Apt(Package):
     
     def _get_version(self):
         version_check = VERSION_CHECK % self.name
-        output = self.test(version_check).split(':')[1].strip()
+        output = self.test(version_check)
         if output is None:
             return None
-        return output      
+        return output.split(':')[1].strip()
  
     def get_default_timeout(self):
         return TIMEOUT

--- a/opsmop/providers/package/package.py
+++ b/opsmop/providers/package/package.py
@@ -25,6 +25,8 @@ class Package(Provider):
 
         # FIXME: this can probably should advantage of the StrictVersion class to be smarter.
         # Setting the absent parameter on Package should override any other parameters
+        if self.update_cache:
+            self.needs('update_cache')
         if self.absent:
             if current_version:
                 self.needs('remove')

--- a/opsmop/providers/package/package.py
+++ b/opsmop/providers/package/package.py
@@ -24,12 +24,14 @@ class Package(Provider):
         current_version = self._get_version()
 
         # FIXME: this can probably should advantage of the StrictVersion class to be smarter.
-        if current_version and self.absent:
-            self.needs('remove')
-        elif not current_version and not self.absent:
-            self.needs('install')
-        elif self.latest:
-            self.needs('upgrade')
-        elif self.version and self.version != current_version:
-            self.needs('upgrade')
-       
+        # Setting the absent parameter on Package should override any other parameters
+        if self.absent:
+            if current_version:
+                self.needs('remove')
+        else:
+            if not current_version:
+                self.needs('install')
+            elif self.latest:
+                self.needs('upgrade')
+            elif self.version and self.version != current_version:
+                self.needs('upgrade')

--- a/opsmop/providers/package/package.py
+++ b/opsmop/providers/package/package.py
@@ -26,7 +26,7 @@ class Package(Provider):
         # FIXME: this can probably should advantage of the StrictVersion class to be smarter.
         if current_version and self.absent:
             self.needs('remove')
-        elif not current_version:
+        elif not current_version and not self.absent:
             self.needs('install')
         elif self.latest:
             self.needs('upgrade')

--- a/opsmop/types/package.py
+++ b/opsmop/types/package.py
@@ -29,7 +29,8 @@ class Package(Type):
             name = Field(kind=str, help="the name of the package to install"),
             version = Field(kind=str, default=None, help="what version to install"),
             latest = Field(kind=bool, default=False, help="if true, upgrade the package regardless of version"),
-            absent = Field(kind=bool, default=False, help="if true, remove the package")
+            absent = Field(kind=bool, default=False, help="if true, remove the package"),
+            update_cache = Field(kind=bool, default=False, help="if true, update the package cache")
         )
 
     def validate(self):


### PR DESCRIPTION
This should fix #14 . I ended up needing to fix a few other things to properly test, but this switches out apt for apt-get with a flag that cleans up the output a bit.

You may want to look at 28f4765 specifically, as I repeated myself and I'm not sure the best way to un-repeat myself. My initial thought is to make an 'install_latest' signal that was called when version isn't specified, and only use 'install' when a version is specified. That would centralize the logic in Package as opposed to having to deal with that case in each of the methods, but then it would only make sense to create an 'upgrade_latest' as well. If you like the sound of that I think I can re-factor this PR although I won't be able to test brew. 

