### PR TITLE
Network sysconfig module

### DIFF
--- a/opsmop/core/easy.py
+++ b/opsmop/core/easy.py
@@ -43,6 +43,8 @@ from opsmop.types.set import Set
 from opsmop.types.shell import Shell
 from opsmop.types.stop import Stop
 from opsmop.types.user import User
+from opsmop.types.interface import Interface
+from opsmop.types.interfaces import Interfaces
 
 __all__ = [
     # common resources
@@ -57,7 +59,7 @@ __all__ = [
     # common types
     'File', 'Directory', 'Echo', 'Service', 'Package', 'Shell', 
     'Set', 'Stop', 'Asserts', 'Debug', 'DebugFacts', 'User',
-    'Group',
+    'Group', 'Interface', 'Interfaces',
 
     # inventory
     'TomlInventory',

--- a/opsmop/facts/platform.py
+++ b/opsmop/facts/platform.py
@@ -138,6 +138,12 @@ class PlatformFacts(Facts):
             return Apt
         return None
 
+    def default_network_manager(self):
+        distro = self.os_distribution()
+        if distro in ['Fedora', 'CentOS Linux', 'Red Hat Linux']:
+            from opsmop.providers.network.sysconfig import SysConfig
+            return SysConfig
+
     def default_service_manager(self):
         # patches welcome! feel free to update this for your distribution        
         distro = self.os_distribution()

--- a/opsmop/providers/network/network.py
+++ b/opsmop/providers/network/network.py
@@ -1,0 +1,53 @@
+# Copyright 2018 Michael DeHaan LLC, <michael@michaeldehaan.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opsmop.providers.provider import Provider
+from opsmop.core.errors import ProviderError
+
+
+
+class LinuxNetwork(Provider):
+
+    def get_interface_config(self, interface):
+        """
+        This method should return an interface type when run. Make sure you override this
+        in your method's class if you are extending this provider
+        """
+        raise ProviderError
+
+    def get_interfaces(self):
+        """
+        TODO: This method should return a dict with the current interfaces available on the system
+        it is keyed by the device name of the interfaces
+
+        Ex: {'eth0': Interface: ens9}
+        """
+        raise ProviderError
+
+    def plan(self):
+        current_interfaces = self._get_interfaces()
+        for interface in self.resource.interfaces:
+            # First validate that the requested interface exists and raise an error if not
+            if interface.device in current_interfaces:
+                current_state = current_interfaces[interface.device]
+                if not current_state:
+                    self.needs('create_interface_{}'.format(interface.device))
+                elif current_state != interface:
+                        self.needs('update_interface_{}'.format(interface.device))
+            else:
+                raise ProviderError(msg="Interface {} does not exist".format(interface.device))
+        if len(self.actions_planned) > 0 and self.auto_reload:
+            self.needs('reload_service')
+
+

--- a/opsmop/providers/network/sysconfig.py
+++ b/opsmop/providers/network/sysconfig.py
@@ -130,10 +130,12 @@ class SysConfig(LinuxNetwork):
                 return False
         # Get a new instance of Interface depending on type
         # TODO: Improve the method used to determine interface type when more types are added
-        if 'type' in options:
-            if options['TYPE'].lower() == 'ethernet' or 'type' not in options:
-                interface_obj = Interface(device=options['device'])
+        if 'TYPE' in options:
+            if options['TYPE'].lower() == 'ethernet':
+                interface_obj = Interface(device=options['DEVICE'])
                 self._populate_interface_attributes_from_file(interface_obj, options)
+            else:
+                self.error(f"The type {options['TYPE']} is not currently supported by this module")
         # If type isn't specified, its probably an Ethernet device
         else:
             interface_obj = Interface(device=options['DEVICE'])

--- a/opsmop/providers/network/sysconfig.py
+++ b/opsmop/providers/network/sysconfig.py
@@ -1,0 +1,194 @@
+# Copyright 2018 Michael DeHaan LLC, <michael@michaeldehaan.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This provider method works with RHEL derivatives (CentOS 6 and newer) that use the network service
+
+from opsmop.providers.network.network import LinuxNetwork
+from opsmop.types.interface import Interface
+
+INTERFACE_FILE_PREFIX = '/etc/sysconfig/network-scripts/ifcfg-{}'
+GET_INTERFACE_DETAILS = "cat /etc/sysconfig/network-scripts/ifcfg-{}"
+RELOAD_CONFIG = "systemctl restart network"
+GET_INTERFACES = "cat /proc/net/dev"
+
+KEY_MAP = {
+            'DEVICE': 'device',
+            'IPADDR': 'ipv4_address',
+            'PREFIX': 'ipv4_prefix',
+            'NETMASK': 'ipv4_netmask',
+            'GATEWAY': 'ipv4_gateway',
+            'METRIC': 'metric',
+            'IPV4_FAILURE_FATAL': 'ipv4_failure_fatal',
+            'ONBOOT': 'on_boot',
+            'BOOTPROTO': 'boot_proto',
+            'MTU': 'mtu',
+            'MACADDR': 'mac_addr'
+        }
+
+class SysConfig(LinuxNetwork):
+
+    def plan(self):
+        super().plan()
+
+    def apply(self):
+        for interface in self.resource.interfaces:
+            if self.should('update_interface_{}'.format(interface.device)):
+                self.do('update_interface_{}'.format(interface.device))
+                self.update_interface(interface)
+            elif self.should('create_interface_{}'.format(interface.device)):
+                self.do('create_interface_{}'.format(interface.device))
+                self.create_interface(interface)
+        if self.should('reload_service'):
+            self.do('reload_service')
+            self.reload_config()
+        return self.ok()
+
+    def _options_from_config(self, sysconfig_text):
+        """
+        Parses a sysconfig text file and returns a dictionary of the keys and values
+        Ex:
+       {
+            'DEVICE': 'ens9',
+            'IPADDR': '10.1.1.143',
+            'NETMASK': '255.255.255.0',
+            'METRIC': 2,
+            'IPV4_FAILURE_FATAL': False,
+            'ONBOOT': True,
+            'BOOTPROTO': 'static',
+            'MTU': 2300
+        }
+        """
+        options = {}
+        for line in sysconfig_text.splitlines():
+            if line.startswith("#") or line.strip() == '':
+                pass
+            else:
+                key, value = line.split("=")
+                value = value.strip('''\'\"''')  # Get rid of quotes surrounding values
+                # Convert 'yes' to True and 'no' to False
+                if value.lower() == 'yes':
+                    value = True
+                elif value.lower() == 'no':
+                    value = False
+                elif value.isdigit():
+                    value = int(value)
+                options.update({key: value})
+        return options
+
+    def _get_reverse_map(self):
+        """
+        This provides a dictionary that maps Interface keys to sysconfig file keys
+        """
+        return {v: k for k, v in KEY_MAP.items()}
+
+    def _populate_interface_attributes_from_file(self, interface_obj, options_dict):
+        """
+        This sets the field values based on a key mapper (since sysconfig and opsmop have different keys)
+        """
+        for (k, v) in KEY_MAP.items():
+            if k in options_dict:
+                setattr(interface_obj, v, options_dict[k])
+        if 'DNS1' or 'DNS2' in options_dict:
+            interface_obj.dns = []
+            if 'DNS1' in options_dict:
+                interface_obj.dns.append(options_dict['DNS1'])
+            if 'DNS2' in options_dict:
+                interface_obj.dns.append(options_dict['DNS2'])
+
+    def get_interface_config(self, interface_device):
+        """
+        This method accepts a string containing the name of the interface device to fetch, and then
+        runs all necesarry methods to collect information about it, parse it, and return it as an Interface Object
+        """
+        # We need to generate an instance of the current state in order to compare the two
+        output = self.test(cmd=GET_INTERFACE_DETAILS.format(interface_device))
+        # File doesn't exist
+        if output is None:
+            # This will cause the state comparison to fail, triggering the nonexistant file to be created
+            return False
+        try:
+            options = self._options_from_config(output)
+        except ValueError:
+            if self.force:
+                return False
+            else:
+                self.error(f"The interfaces file for {interface_device} could not be read,"
+                f" add the 'force' parameter to your Interfaces resource to overwrite it anyways.")
+        # Ensure that DEVICE is present, if there is no DEVICE try to use the name
+        if 'DEVICE' not in options:
+                return False
+        # Get a new instance of Interface depending on type
+        # TODO: Improve the method used to determine interface type when more types are added
+        if 'type' in options:
+            if options['TYPE'].lower() == 'ethernet' or 'type' not in options:
+                interface_obj = Interface(device=options['device'])
+                self._populate_interface_attributes_from_file(interface_obj, options)
+        # If type isn't specified, its probably an Ethernet device
+        else:
+            interface_obj = Interface(device=options['DEVICE'])
+            self._populate_interface_attributes_from_file(interface_obj, options)
+        return interface_obj
+
+    def _get_interfaces(self):
+        """
+        This returns a list of interfaces present on the system
+        """
+        valid_interfaces = {}
+        output = self.test(GET_INTERFACES)
+        for line in output.split('\n'):
+            if ':' in line:
+                if_name = line.split(':')[0].strip()
+                valid_interfaces.update({if_name: self.get_interface_config(if_name)})
+        return valid_interfaces
+
+    def set_interface_config(self, interface):
+        """
+        This generates an ifcfg-{devname} file and writes it to the filesystem of the machine
+        """
+        interface_config_lines = []
+        # This gets the reverse of the key map specified above to map OpsMop keys to sysconfig keys
+        for k, mapped_key in self._get_reverse_map().items():
+            value = getattr(interface, k)
+            # True and False map to "YES" and "NO" in sysconfig files
+            if value is True:
+                value = 'YES'
+            elif value is False:
+                value = 'NO'
+            if value is not None:
+                interface_config_lines.append(f"{mapped_key}={value}\n")
+        # DNS servers are a special case, since it accepts a list as a parameter
+        if interface.dns:
+            # Sysconfig can only accept two DNS servers at most
+            for idx, srv in enumerate(interface.dns[0:2]):
+                interface_config_lines.append(f"DNS{idx + 1}={srv}\n")
+        self.echo(msg="New Interface Config:")
+        for line in interface_config_lines:
+            self.echo(msg=line.strip('\n'))
+        with open(INTERFACE_FILE_PREFIX.format(interface.device), 'w+') as file:
+            file.writelines(interface_config_lines)
+        return True
+
+    def create_interface(self, interface):
+        """Wrapper for when we are making an interface"""
+        return self.set_interface_config(interface)
+
+    def update_interface(self, interface):
+        """Wrapper for when we are updating an interface"""
+        return self.set_interface_config(interface)
+
+    def reload_config(self):
+        """Reload the systemctl config"""
+        self.run(RELOAD_CONFIG)
+
+

--- a/opsmop/types/interface.py
+++ b/opsmop/types/interface.py
@@ -1,0 +1,110 @@
+# Copyright 2018 Michael DeHaan LLC, <michael@michaeldehaan.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opsmop.core.field import Field
+from opsmop.core.fields import Fields
+from opsmop.core.resource import Resource
+from opsmop.core.errors import ValidationError, NoSuchProviderError
+from ipaddress import IPv4Address, AddressValueError
+
+NETWORK_FIELDS = [
+            'device',
+            'ipv4_address',
+            'ipv4_prefix',
+            'ipv4_netmask',
+            'ipv4_gateway',
+            'ipv4_failure_fatal',
+            'metric',
+            'on_boot',
+            'boot_proto',
+            'mtu',
+            'dns',
+            'mac_addr'
+        ]
+ALLOWED_BOOT_PROTO_VALUES = ['none', 'dhcp', 'bootp']
+
+
+class Interface(Resource):
+
+    def __init__(self, device=None, **kwargs):
+        self.setup(device=device, **kwargs)
+
+    def __eq__(self, other):
+        return all(getattr(self, key) == getattr(other, key) for key in NETWORK_FIELDS)
+
+    def fields(self):
+        return Fields(
+            self,
+            device=Field(kind=str, default=None, help="Name of physical devicelogical name"),
+            ipv4_address=Field(kind=str, default=None, help="IPv4 address of the interface("),
+            ipv4_prefix=Field(kind=int, default=None, help="Prefix of the IPv4 network "
+                                                           "(ex: prefix=24 == ipv4_netmask=255.255.255.0)"),
+            ipv4_netmask=Field(kind=str, default=None, help="IPv4 netmask of the interface "
+                                                            "(ex: ipv4_netmask=255.255.255.0 == prefix=24)"),
+            ipv4_gateway=Field(kind=str, default=None, help="IPv4 gateway of the interface"),
+            ipv4_failure_fatal=Field(kind=bool, default=False, help="If True, the configuration of the "
+                                                                    "interface will fail if dchlient fails"),
+            metric=Field(kind=int, default=None, help="The metric of the interface"),
+            on_boot=Field(kind=bool, default=True, help="Controls whether or not the interface is active on boot"),
+            boot_proto=Field(kind=str,
+                             default='none',
+                             help="'bootp' or 'dhcp' cause a DHCP client to run on the device."
+                                  " Any other value causes any static configuration in the file to be applied."),
+            mtu=Field(kind=int, default=1500, help="Configures interface maximum frame size in bytes."),
+            # TODO: Process DNS parameter
+            dns=Field(kind=list, default=None,
+                      help="Accepts up to two DNS servers. Using this option on multiple interfaces in the same "
+                           "system may produce unexpected results"),
+            mac_addr=Field(kind=str,
+                           default=None,
+                           help="Ethernet hardware address for this device, ex: 'AA:BB:CC:DD:EE:FF'"),
+        )
+
+    def _field_str_validator(self, field, allowed_options):
+        if field not in allowed_options:
+            options = ', '.join(allowed_options)
+            raise ValidationError(msg=f"Field {field} must contain one of the following options {options}.")
+
+    def validate(self):
+        """
+        We need to do a few things here:
+        validate that any str options contain allowed values
+        validate that all IP and MAC addresses are formatted correctly
+        ensure that any list with a required length isn't too long (such as DNS)
+        """
+
+        fields_to_validate = [
+            (self.boot_proto, ALLOWED_BOOT_PROTO_VALUES)
+        ]
+        for f in fields_to_validate:
+            if f[0]:
+                self._field_str_validator(f[0], f[1])
+
+        # Validate list lengths
+        if self.dns:
+            if self.dns.__len__() > 2:
+                #TODO: validate that the servers are formatted as proper IP strings
+                raise ValidationError(msg="DNS option cannot contain more than two dns servers")
+            for server in self.dns:
+                try:
+                    IPv4Address(server)
+                except AddressValueError as e:
+                    raise ValidationError(msg=f'DNS validation failed {server} is not a valid IP address: {e}')
+        #TODO: Validate MAC addresses
+        #TODO: Validate IP addresses
+        if self.ipv4_address:
+            try:
+                IPv4Address(self.ipv4_address)
+            except AddressValueError as e:
+                raise ValidationError(msg=f'Interface {self.device} failed validation: {e}')

--- a/opsmop/types/interfaces.py
+++ b/opsmop/types/interfaces.py
@@ -1,0 +1,65 @@
+# Copyright 2018 Michael DeHaan LLC, <michael@michaeldehaan.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opsmop.core.field import Field
+from opsmop.core.fields import Fields
+from opsmop.types.interface import Interface
+from opsmop.types.type import Type
+from opsmop.core.errors import ValidationError
+from opsmop.facts.platform import Platform
+
+
+class Interfaces(Type):
+
+    def __init__(self, *interfaces, **kwargs):
+        self.setup(**kwargs)
+        self.interfaces = list(interfaces)
+
+    def fields(self):
+        return Fields(
+            self,
+            auto_reload=Field(kind=bool,
+                              default=False,
+                              help="Auto reloads the networking service if changes are made. Default: False"),
+            force=Field(kind=bool,
+                        default=False,
+                        help="Overwrite configuration even if the original file cannot be parsed.")
+            )
+
+    def add(self, interface):
+        """
+        Adds interface(s) to the resource
+        """
+        if isinstance(interface, Interface):
+            self.interfaces.append(interface)
+        elif isinstance(interface, list):
+            for interf in interface:
+                if isinstance(interf, Interface):
+                    self.interfaces.append(interf)
+                else:
+                    raise ValidationError(msg="You can only add interface objects to an interfaces type")
+        else:
+            raise ValidationError(msg="You can only add interface objects to an interfaces type")
+
+    def get_provider(self, method):
+        if method == 'sysconfig':
+            from opsmop.providers.network.sysconfig import SysConfig
+            return SysConfig
+
+    def default_provider(self):
+        return Platform.default_network_manager()
+
+    def validate(self):
+        for interface in self.interfaces:
+            interface.validate()


### PR DESCRIPTION
Here is a mostly feature-complete version of the sysconfig provider and associated types (for physical interfaces only, right now.) A few things to point out:

In regards to signals, I wanted to make sure I'm using them sanely. I'm dynamically generating the signal name based on the sub-resource that needs an operation, I.E.:
```
--------------------------
1. HelloRole => Interfaces

    parameters:
        | auto_reload: True
        | method: sysconfig
    planning...
        # cat /proc/net/dev
        | Inter-|   Receive                                                |  Transmit
        |  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
        |   ens9:    2934      16  890    0    0   890          0         0      530       8    0    0    0     0       0          0
        |   eth0: 15318332    3259    0    7    0     0          0         0   484770    2753    0    0    0     0       0          0
        |     lo:    1740      20    0    0    0     0          0         0     1740      20    0    0    0     0       0          0
        = ok, rc=0
        # cat /etc/sysconfig/network-scripts/ifcfg-ens9
        | DEVICE=ens9
        | IPADDR=10.1.1.123
        | NETMASK=255.255.255.0
        | METRIC=2
        | IPV4_FAILURE_FATAL=NO
        | ONBOOT=YES
        | BOOTPROTO=static
        | MTU=2300
        = ok, rc=0
    do: update_interface_ens9
        | New Interface Config:
        | DEVICE=ens9
        | IPADDR=10.1.1.143
        | NETMASK=255.255.255.0
        | METRIC=2
        | IPV4_FAILURE_FATAL=NO
        | ONBOOT=YES
        | BOOTPROTO=static
        | MTU=2300
    do: reload_service
        # systemctl restart network
        | (no output)
        = ok, rc=0
    ok

---------
complete!

```

This seemed like I was using signals correctly at the time, but wanted to make sure this was a good way to address sub-resource planning.

I created a class in the interface type module to classify interface types as abstract (as we mentioned in the forum thread):

```
class InterfaceAbstract(Type):
    is_abstract = True
```
So we could check for that in whatever component validates resources to ensure people aren't sticking it directly where a normal resource should go. If you don't like that convention, it can be easily modified, but I figure it needs to live outside of the interface type module either way (I just couldn't figure out an obvious place to stick it). 

Also, if you can point me to where the validation change should be made to raise a ValidationError when people try to return an abstract resource I would be more than happy to take a crack at that validation step.

Example usage is like so: (I'll add a more complete example to the docs assuming you don't request any changes).

```
from opsmop.core.easy import *
from opsmop.types.interfaces import Interfaces, Interface

class NetworkRole(Role):

    def set_variables(self):
        return dict(program='OpsMop')

    def set_resources(self):
        ifaces = Interfaces(method='sysconfig', auto_reload=True)
        ifaces.add(Interface(name='ens9',
                             mtu=2300,
                             ipv4_address='10.1.1.143',
                             ipv4_netmask='255.255.255.0',
                             metric=2,
                             on_boot=True,
                             boot_proto='static',
                             ))
        return Resources(
            ifaces
        )


# -----------------

class NetTest(Policy):

    def set_variables(self):
        return dict()

    def set_roles(self):
        return Roles(NetworkRole())


def main():
    return NetTest()
```

I want to nail down the structure before I add the rest of the params and abstract types (although it would probably be sufficient for a large portion of use-cases as is). Let me know what you think.