### PR TITLE
Properly indent multiline messages

### DIFF
--- a/opsmop/callbacks/callback.py
+++ b/opsmop/callbacks/callback.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import textwrap
 
 from opsmop.client.user_defaults import UserDefaults
 
@@ -61,5 +62,5 @@ class BaseCallbacks(object):
     
     def _indent(self, level, msg):
         spc = INDENT * level
-        print("%s%s" % (spc, msg))
+        print(textwrap.indent(str(msg), spc))
         self.logger.info(msg)

--- a/opsmop/providers/echo.py
+++ b/opsmop/providers/echo.py
@@ -14,6 +14,7 @@
 
 import os
 import shutil
+import subprocess
 
 from opsmop.core.template import Template
 from opsmop.providers.provider import Provider
@@ -38,7 +39,7 @@ class Echo(Provider):
 
         if self.cowsay and os.environ.get('MOO'):
             cmd = COWSAY.format(msg=txt)
-            txt = self.run(cmd, echo=False)
+            txt = subprocess.check_output(cmd, shell=True).decode()
         self.echo(txt)
 
         return self.ok()


### PR DESCRIPTION
When message is multiline, only first line would be indented.