### PR TITLE
Clarify Python 3.6 is required, not just python 3.

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -14,7 +14,7 @@ Setup
 Python 3
 --------
 
-OpsMop requires Python 3.  
+OpsMop requires Python 3.6 or higher.
 
 .. _python3_linux:
 


### PR DESCRIPTION
Discovered on Python3.5.3 via Stretch that 3.x isn't enough.

Later comment suggests 3.6, but without specifying requirement it sounds like a recommendation.

f strings necessitate python >3.6